### PR TITLE
add code to generate birth weight risk correlation data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,6 @@ if __name__ == "__main__":
             make_specs=vivarium_gates_bep.tools.cli:make_specs
             make_artifacts=vivarium_gates_bep.tools.cli:make_artifacts
             make_results=vivarium_gates_bep.tools.cli:make_results
+            make_bw_risk_correlation=vivarium_gates_bep.tools.cli:make_bw_risk_correlation
         '''
     )

--- a/src/vivarium_gates_bep/model_specifications/bw_risk_corr_spec.in
+++ b/src/vivarium_gates_bep/model_specifications/bw_risk_corr_spec.in
@@ -1,0 +1,35 @@
+components:
+    vivarium_gates_bep.components:
+        - NewbornPopulation()
+        - LBWSGRisk()
+
+configuration:
+    input_data:
+        location: {{ location_proper }}
+        input_draw_number: 0
+        artifact_path: /share/costeffectiveness/artifacts/vivarium_gates_bep/{{ location_sanitized }}.hdf
+    interpolation:
+        order: 0
+        extrapolate: True
+    randomness:
+        map_size: 1_000_000
+        key_columns: ['index']
+        random_seed: 0
+    time:
+        start:
+            year: 2020
+            month: 7
+            day: 2
+        end:
+            year: 2020
+            month: 7
+            day: 3
+        step_size: 1 # Days
+    population:
+        population_size: 100_000
+        age_start: 0
+        age_end: 0
+    child_wasting:
+        category_thresholds: [7, 8, 9]
+    child_stunting:
+        category_thresholds: [7, 8, 9]

--- a/src/vivarium_gates_bep/model_specifications/bw_risk_corr_spec.in
+++ b/src/vivarium_gates_bep/model_specifications/bw_risk_corr_spec.in
@@ -26,7 +26,7 @@ configuration:
             day: 3
         step_size: 1 # Days
     population:
-        population_size: 100_000
+        population_size: 1_000_000
         age_start: 0
         age_end: 0
     child_wasting:

--- a/src/vivarium_gates_bep/tools/cli.py
+++ b/src/vivarium_gates_bep/tools/cli.py
@@ -27,6 +27,7 @@ from .app_logging import configure_logging_to_terminal
 from .make_specs import build_model_specifications
 from .make_artifacts import build_artifacts
 from .make_results import build_results
+from .make_bw_risk_correlation import build_bw_rc_data
 
 
 @click.command()
@@ -69,6 +70,42 @@ def make_specs(template: str, location: str, output_dir: str, verbose: int, with
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(build_model_specifications, logger, with_debugger=with_debugger)
     main(template, location, output_dir)
+
+
+@click.command()
+@click.option('-t', '--template',
+              default=str(paths.MODEL_SPEC_DIR / 'bw_risk_corr_spec.in'),
+              show_default=True,
+              type=click.Path(exists=True, dir_okay=False),
+              help='The birth weight risk correlation model specification template file.')
+@click.option('-l', '--location',
+              default='all',
+              show_default=True,
+              type=click.Choice(project_globals.LOCATIONS + ['all']),
+              help='Location to make specification for.')
+@click.option('-o', '--output-dir',
+              default=str(paths.MODEL_SPEC_DIR),
+              show_default=True,
+              type=click.Path(exists=True),
+              help='Specify an output directory. Directory must exist.')
+@click.option('-v', 'verbose',
+              count=True,
+              help='Configure logging verbosity.')
+@click.option('--pdb', 'with_debugger',
+              is_flag=True,
+              help='Drop into python debugger if an error occurs.')
+def make_bw_risk_correlation(template: str, location: str, output_dir: str, verbose: int, with_debugger: bool) -> None:
+    """Generate model specifications based on a template.
+
+    The default template lives here:
+
+    ``vivarium_gates_bep/src/vivarium_gates_bep/model_specification/bw_risk_model_spec.in``
+
+    """
+    configure_logging_to_terminal(verbose)
+    main = handle_exceptions(build_bw_rc_data, logger, with_debugger=with_debugger)
+    main(template, location, output_dir)
+
 
 
 @click.command()

--- a/src/vivarium_gates_bep/tools/make_bw_risk_correlation.py
+++ b/src/vivarium_gates_bep/tools/make_bw_risk_correlation.py
@@ -11,18 +11,13 @@ from vivarium_gates_bep.tools.make_specs import build_model_specifications
 LARGER_THAN_LARGEST_BABY_ON_RECORD = 25 * 454
 
 
-def empirical_percentile(x, samples):
-    return np.mean(x >= samples)
-
-
 def create_bw_rc_data(spec_file: str):
     sim = InteractiveContext(spec_file)
     df = pd.DataFrame()
     df['birth_weights'] = sim.get_population().birth_weight
 
     # rank birth weights
-    df['birth_weight_percentile'] = df.birth_weights.apply(empirical_percentile, samples=df.birth_weights)
-    df = df.sort_values(by=['birth_weight_percentile'])
+    df = df.sort_values(by=['birth_weights'])
 
     # create upper and lower bounds, fill starting and ending bins appropriately
     df['bw_lower_bound'] = df.birth_weights.shift(periods=1, fill_value=0.0)
@@ -63,3 +58,4 @@ def build_bw_rc_data(template: str, location: str, output_dir: str):
     bw_risk_corr_specs = Path(output_dir).glob('*_bw_risk_corr.yaml')
     for loc in bw_risk_corr_specs:
         create_bw_rc_data(str(loc))
+        loc.unlink()

--- a/src/vivarium_gates_bep/tools/make_bw_risk_correlation.py
+++ b/src/vivarium_gates_bep/tools/make_bw_risk_correlation.py
@@ -1,0 +1,65 @@
+"""Application functions for producing specification files from which we derive birth weight risk correlation."""
+import numpy as np
+import pandas as pd
+
+from pathlib import Path
+
+from vivarium import InteractiveContext
+from vivarium_gates_bep.tools.make_specs import build_model_specifications
+
+
+LARGER_THAN_LARGEST_BABY_ON_RECORD = 25 * 454
+
+
+def empirical_percentile(x, samples):
+    return np.mean(x >= samples)
+
+
+def create_bw_rc_data(spec_file: str):
+    sim = InteractiveContext(spec_file)
+    df = pd.DataFrame()
+    df['birth_weights'] = sim.get_population().birth_weight
+
+    # rank birth weights
+    df['birth_weight_percentile'] = df.birth_weights.apply(empirical_percentile, samples=df.birth_weights)
+    df = df.sort_values(by=['birth_weight_percentile'])
+
+    # create upper and lower bounds, fill starting and ending bins appropriately
+    df['bw_lower_bound'] = df.birth_weights.shift(periods=1, fill_value=0.0)
+    df['bw_upper_bound'] = df.birth_weights
+    df.bw_upper_bound.iloc[-1] = LARGER_THAN_LARGEST_BABY_ON_RECORD
+
+    # drop the redundant column and write the output file
+    df = df.drop('birth_weights', axis=1)
+    outfile = f'{Path(spec_file).stem}.csv'
+    df.to_csv(outfile, index=False)
+    del sim
+
+
+def build_bw_rc_data(template: str, location: str, output_dir: str):
+    """Writes model specifications from a template and location that
+    are used to produce birth weight propensities and ranked bins.
+
+    Parameters
+    ----------
+    template
+        String path to the model specification template file.
+    location
+        Location to generate the model specification for. Must be a
+        location configured in the project ``globals.py`` or ``'all'``
+        to generate all model specifications.
+    output_dir
+        String path to the output directory where the model specification(s)
+        will be written.
+
+    Raises
+    ------
+    ValueError
+        If the provided location in not ``'all'`` or is not one of the
+        locations configured in the project ``globals.py``.
+
+    """
+    build_model_specifications(template, location, output_dir, '_bw_risk_corr')
+    bw_risk_corr_specs = Path(output_dir).glob('*_bw_risk_corr.yaml')
+    for loc in bw_risk_corr_specs:
+        create_bw_rc_data(str(loc))

--- a/src/vivarium_gates_bep/tools/make_specs.py
+++ b/src/vivarium_gates_bep/tools/make_specs.py
@@ -8,7 +8,7 @@ from vivarium_gates_bep import globals as project_globals
 from vivarium_gates_bep.utilites import sanitize_location
 
 
-def build_model_specifications(template: str, location: str, output_dir: str):
+def build_model_specifications(template: str, location: str, output_dir: str, suffix : str =''):
     """Builds and writes model specifications from a template and location.
 
     Parameters
@@ -49,7 +49,7 @@ def build_model_specifications(template: str, location: str, output_dir: str):
 
     for location in locations:
         sanitized_location = sanitize_location(location)
-        file_path = output_dir / f'{sanitized_location}.yaml'
+        file_path = output_dir / f'{sanitized_location}{suffix}.yaml'
         with file_path.open('w+') as outfile:
             logger.debug(f'Writing {file_path.name}.')
             rendered_template = jinja_template.render(location_proper=location, location_sanitized=sanitized_location)


### PR DESCRIPTION
Add a new click app that:
	1.) Creates stripped down model spec files for use in generating birth weight risk data
	2.) Initializes a simulation to obtain LBWSG birth weight data and creates a ranked view of the data
	
New files:
	- stripped down spec template (bw_risk_corr_spec.in)
	- python file (make_bw_risk_correlation.py)
	
Other:
	- small change to build_model_specifcations() to allow it to produce alternately-named output files.